### PR TITLE
Fix wait-for-services for non-root users.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ install:
     - docker build -t aiida-prerequisites .
     - docker run -d aiida-prerequisites
     - "export DOCKERID=`docker ps -qf 'ancestor=aiida-prerequisites'`"
-    - docker exec --tty $DOCKERID wait-for-services
+    - docker exec --tty --user root $DOCKERID wait-for-services
+    - docker exec --tty --user aiida $DOCKERID wait-for-services
 
 # Check that PostgreSQL and RabbitMQ are up.
 script:

--- a/bin/wait-for-services
+++ b/bin/wait-for-services
@@ -2,7 +2,7 @@
 set -em
 
 while true; do
-   if [[ -f /root/INIT_COMPLETED ]] ; then
+   if [[ -f /opt/INIT_COMPLETED ]] ; then
        break
    fi
    sleep 1

--- a/my_init.d/finalize_init.sh
+++ b/my_init.d/finalize_init.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -em
 
-touch /root/INIT_COMPLETED
+touch /opt/INIT_COMPLETED
 


### PR DESCRIPTION
Before, the `INIT_COMPLETED` file was put into `/root` folder which is inaccessible to the normal users. Now it is put in `/opt`.