### PR TITLE
Set conda as the base python environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@
 FROM phusion/baseimage:0.11
 MAINTAINER AiiDA Team
 
-# Initial parameters
-
 # Use the following arguments during *build* time:
 # $ docker build  --build-arg NB_UID=200
 ARG NB_USER="aiida"
@@ -17,26 +15,31 @@ ENV SYSTEM_USER ${NB_USER}
 ENV SYSTEM_USER_UID ${NB_UID}
 ENV SYSTEM_USER_GID ${NB_GID}
 ENV PYTHONPATH /home/$SYSTEM_USER
+ENV CONDA_DIR /opt/conda
+ENV PATH $CONDA_DIR/bin:$PATH
+ENV MINICONDA_VERSION 4.7.12.1
+ENV MINICONDA_MD5 81c773ff87af5cfac79ab862942ab6b3
+ENV CONDA_VERSION 4.8.2
 
 USER root
 
-# Fix locales
+# Fix locales.
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-# Add switch mirror to fix the issue
+# Add switch mirror to fix the issue.
 # https://github.com/aiidalab/aiidalab-docker-stack/issues/9
 RUN echo "deb http://mirror.switch.ch/ftp/mirror/ubuntu/ bionic main \ndeb-src http://mirror.switch.ch/ftp/mirror/ubuntu/ bionic main \n" >> /etc/apt/sources.list
 
-# install debian packages
+# Install debian packages.
 # Note: prefix all 'apt-get install' lines with 'apt-get update' to prevent failures in partial rebuilds
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     tzdata
 
-# Install required ubuntu packages
+# Install required ubuntu packages.
 RUN apt-get update && apt-get install -y --no-install-recommends  \
     build-essential       \
     bzip2                 \
@@ -48,15 +51,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends  \
     less                  \
     postgresql            \
     psmisc                \
-    python3-dev           \
-    python3-gi            \
-    python3-gi-cairo      \
-    python3-pip           \
-    python3-psycopg2      \
-    python3-setuptools    \
-    python3-tk            \
-    python3-wheel         \
-    python-tk             \
     rabbitmq-server       \
     rsync                 \
     ssh                   \
@@ -67,11 +61,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends  \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean all
 
-# Set Python3 be the default python version
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-
-# update build-tools
-RUN pip3 install -U pip setuptools wheel
+# Install conda.
+RUN cd /tmp && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    echo "${MINICONDA_MD5} *Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh" | md5sum -c - && \
+    /bin/bash Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh -f -b -p $CONDA_DIR && \
+    rm Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    echo "conda ${CONDA_VERSION}" >> $CONDA_DIR/conda-meta/pinned && \
+    conda config --system --prepend channels conda-forge && \
+    conda config --system --set auto_update_conda false && \
+    conda config --system --set show_channel_urls true && \
+    conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
+    conda install --quiet --yes conda && \
+    conda install --quiet --yes pip && \
+    conda update --all --quiet --yes && \
+    conda clean --all -f -y
 
 # Launch rabbitmq server
 COPY my_init.d/start-rabbitmq.sh /etc/my_init.d/10_start-rabbitmq.sh
@@ -88,6 +92,9 @@ COPY my_init.d/finalize_init.sh /etc/my_init.d/99_finalize_init.sh
 
 # Add wait-for-services script.
 COPY bin/wait-for-services /usr/local/bin/wait-for-services
+
+# Enable prompt color in the skeleton .bashrc before creating the default ${SYSTEM_USER}.
+RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc
 
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]

--- a/my_init.d/create-system-user.sh
+++ b/my_init.d/create-system-user.sh
@@ -47,3 +47,6 @@ fi
 if [[ ${PERFORM_CHOWN} == true ]]; then
   chown ${SYSTEM_USER}:${SYSTEM_USER} /home/${SYSTEM_USER} -R
 fi
+
+# Prepare conda.
+su ${SYSTEM_USER} -c "/opt/conda/bin/conda init" 


### PR DESCRIPTION
This PR removes all python installations outside of conda. From now on python environment
will only be available under conda.

In addition, the PR adds a line to prettify command-line interface by setting `force_color_prompt=yes`