### PR TITLE
Fix group access rights of .postgresql folder.

### DIFF
--- a/opt/start-postgres.sh
+++ b/opt/start-postgres.sh
@@ -16,6 +16,9 @@ if [ ! -d /home/${SYSTEM_USER}/.postgresql ]; then
 
 # else don't
 else
+    # Fix problem with kubernetes cluster that adds rws permissions to the group
+    # for more details see: https://github.com/materialscloud-org/aiidalab-z2jh-eosc/issues/5
+    chmod g-rwxs /home/${SYSTEM_USER}/.postgresql -R
 
     # stores return value in $?
     running=true


### PR DESCRIPTION
For some reason kubernetes adds rws permissions to the
~/.postgresql folder. Postgres does only allows to have 700
permissions. Providing a temporary fix.