### PR TITLE
Move the mnesia folder of RabbitMQ to `/home/${SYSTEM_USER}`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,11 +83,11 @@ RUN cd /tmp && \
 # This is needed to let non-root users create conda environments.
 RUN mkdir /opt/conda/pkgs && touch /opt/conda/pkgs/urls.txt
 
-# Launch rabbitmq server
-COPY my_init.d/start-rabbitmq.sh /etc/my_init.d/10_start-rabbitmq.sh
-
 # Create system user.
-COPY my_init.d/create-system-user.sh /etc/my_init.d/20_create-system-user.sh
+COPY my_init.d/create-system-user.sh /etc/my_init.d/10_create-system-user.sh
+
+# Launch rabbitmq server
+COPY my_init.d/start-rabbitmq.sh /etc/my_init.d/20_start-rabbitmq.sh
 
 # Launch postgres server.
 COPY opt/start-postgres.sh /opt/start-postgres.sh

--- a/my_init.d/start-rabbitmq.sh
+++ b/my_init.d/start-rabbitmq.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
 set -em
 
+DIR_RABBITMQ="/home/${SYSTEM_USER}/.rabbitmq"
+
+mkdir -p "${DIR_RABBITMQ}"
+chown rabbitmq:rabbitmq "${DIR_RABBITMQ}"
+
+# Set base directory for RabbitMQ to persist its data. This needs to be set to a folder in the system user's home
+# directory as that is the only folder that is persisted outside of the container.
+echo MNESIA_BASE="${DIR_RABBITMQ}" >> /etc/rabbitmq/rabbitmq-env.conf
+echo LOG_BASE="${DIR_RABBITMQ}/log" >> /etc/rabbitmq/rabbitmq-env.conf
+
+# Explicitly define the node name. This is necessary because the mnesia subdirectory contains the hostname, which by
+# default is set to the value of $(hostname -s), which for docker containers, will be a random hexadecimal string. Upon
+# restart, this will be different and so the original mnesia folder with the persisted data will not be found. The
+# reason RabbitMQ is built this way is through this way it allows to run multiple nodes on a single machine each with
+# isolated mnesia directories. Since in the AiiDA setup we only need and run a single node, we can simply use localhost.
+echo NODENAME=rabbit@localhost >> /etc/rabbitmq/rabbitmq-env.conf
+
 service rabbitmq-server start


### PR DESCRIPTION
Fixes #16 

AiiDA relies on RabbitMQ to persist the tasks that correspond to active
processes such that when the daemon and even the machine is rebooted,
upon restart the processes can be resumed. RabbitMQ persists this data
to disk, in a folder called the "mnesia" folder, which by default for
Debian based OS's is located at `/var/lib/rabbitmq/mnesia`. Since this
location is not persisted outside of the container, all tasks
corresponding to incompleted AiiDA processes would be lost when the
container was stopped.

The solution is to reconfigure RabbitMQ to store the mnesia folder in
the `/home/${SYSTEM_USER}` folder, which is the one volume that is
persisted outside of the container. Since this folder is created by the
`create-system-user.sh` initialization script, it had to be moved to be
run before the `start-rabbitmq.sh` script.

Finally, the `start-rabbitmq.sh` script adds the `NODENAME` variable to
the RabbitMQ configuration file. This is necessary because the mnesia
subdirectory contains the hostname, which by default is set to the value
of $(hostname -s), which for docker containers, will be a random
hexadecimal string. Upon restart, this will be different and so the
original mnesia folder with the persisted data will not be found.

The reason RabbitMQ is built this way is through this way it allows to
run multiple nodes on a single machine each with isolated mnesia
directories. Since in the AiiDA setup we only need and run a single
node, we can simply use localhost.