### PR TITLE
Update the base image to `phusion/baseimage:bionic-1.0.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # See https://github.com/phusion/baseimage-docker/blob/master/Changelog.md
 # Based on Ubuntu 18.04 since v0.11
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:bionic-1.0.0
 MAINTAINER AiiDA Team
 
 # Use the following arguments during *build* time:


### PR DESCRIPTION
Fixes #15 

Migrate to the latest stable Bionic Beaver (18.04) Ubuntu distribution.
The old version `phusion/baseimage:0.11` is over two years old and at
the point of writing contains 4 critical security vulnerabilities. We
cannot yet migrate straight to Focal Fossa (20.04) since only an alpha
version release is available for now.