### PR TITLE
Install ruaml.yaml via conda.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,11 @@ RUN cd /tmp && \
     conda update --all --quiet --yes && \
     conda clean --all -f -y
 
+# Upgrade ruamel.py version. Fixes https://github.com/aiidateam/aiida-core/issues/4339.
+RUN conda install ruamel.yaml==0.16.10
+
 # This is needed to let non-root users create conda environments.
-RUN mkdir /opt/conda/pkgs && touch /opt/conda/pkgs/urls.txt
+RUN touch /opt/conda/pkgs/urls.txt
 
 # Create system user.
 COPY my_init.d/create-system-user.sh /etc/my_init.d/10_create-system-user.sh


### PR DESCRIPTION
There are two different packages available on conda: `ruamel.yaml`
and `ruamel_yaml`. Pip cannot distinguish them, therefore we
have to install `ruamel.yaml` via conda.