### PR TITLE
Start ssh-agent at user's startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,9 @@ RUN conda install ruamel.yaml==0.16.10
 # This is needed to let non-root users create conda environments.
 RUN touch /opt/conda/pkgs/urls.txt
 
+# Copy the script load-singlesshagent.sh to /usr/local/bin.
+COPY bin/load-singlesshagent.sh /usr/local/bin/load-singlesshagent.sh
+
 # Create system user.
 COPY my_init.d/create-system-user.sh /etc/my_init.d/10_create-system-user.sh
 

--- a/bin/load-singlesshagent.sh
+++ b/bin/load-singlesshagent.sh
@@ -1,4 +1,6 @@
-# Make sure you source this script rather than executing it
+# This script ensures that the environment variables for the SSH agent are reused by all shells (including the AiiDA daemon)
+# See https://aiida.readthedocs.io/projects/aiida-core/en/v1.5.0/howto/ssh.html
+# Make sure to source this script rather than executing it
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
 then
     echo "You need to source this script, stopping." >&2

--- a/bin/load-singlesshagent.sh
+++ b/bin/load-singlesshagent.sh
@@ -1,0 +1,67 @@
+# Make sure you source this script rather than executing it
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+    echo "You need to source this script, stopping." >&2
+    exit 1
+fi
+
+# run as
+# source load-singlesshagent.sh -v
+# for verbose output
+
+load_singlesshagent() {
+    local VERBOSE
+    local SSH_ENV
+    local SSH_ADD_OUTPUT
+    local SSHADD_RETVAL
+    local NUMKEYS
+
+    VERBOSE=false
+    if [ "$1" == "-v" ]
+    then
+        VERBOSE=true
+    fi
+
+    [ "$VERBOSE" == "true" ] && echo "Single SSH agent script [verbose mode]" >&2
+    SSH_ENV="$HOME/.ssh/agent-environment"
+    # Source SSH settings, if applicable
+    if [ -r "${SSH_ENV}" ]; then
+        source "${SSH_ENV}" > /dev/null
+        [ "$VERBOSE" == "true" ] && echo "- sourcing existing environment" >&2
+    else
+        [ "$VERBOSE" == "true" ] && echo "- no existing environment to source" >&2
+    fi
+
+    SSH_ADD_OUTPUT=`ssh-add -l`
+    # Needed, the later 'test' calls will replace this
+    SSHADD_RETVAL="$?"
+    # Error code: 0: there are keys; 1: there are no keys; 2: cannot contact agent
+    if [ "$SSHADD_RETVAL" == "2" ]
+    then
+        [ "$VERBOSE" == "true" ] && echo "  - unable to contact agent, creating a new one" >&2
+        (umask 066; ssh-agent > ${SSH_ENV})
+        source "${SSH_ENV}" > /dev/null
+    elif [ "$SSHADD_RETVAL" == "1" ]
+    then
+        [ "$VERBOSE" == "true" ] && echo "  - ssh-agent found (${SSH_AGENT_PID}), no keys (I might want to add keys here)" >&2
+        # Maybe the user wants to do it by himself?
+        #ssh-add
+    elif [ "$SSHADD_RETVAL" == "0" ]
+    then
+        NUMKEYS=`echo "$SSH_ADD_OUTPUT" | wc -l`
+        [ "$VERBOSE" == "true" ] && echo "  - ssh-agent found (${SSH_AGENT_PID}) with $NUMKEYS keys" >&2
+    else
+        [ "$VERBOSE" == "true" ] && echo "  - ssh-add replied with return code $SSHADD_RETVAL - I don't know what to do..." >&2
+    fi
+
+    [ "$VERBOSE" == "true" ] && echo "- Debugging, listing all ssh-agents for user $USER:"
+    [ "$VERBOSE" == "true" ] && ps -U "$USER" | grep --color=no '[s]sh-agent'
+}
+
+# Run with the requested verbosity
+if [ "$1" == "-v" ]
+then
+    load_singlesshagent -v
+else
+    load_singlesshagent
+fi

--- a/my_init.d/create-system-user.sh
+++ b/my_init.d/create-system-user.sh
@@ -19,6 +19,9 @@ chown ${SYSTEM_USER}:${SYSTEM_USER} /home/${SYSTEM_USER}
 if [[ ! -f /home/${SYSTEM_USER}/.bashrc ]]; then
   cp -v /etc/skel/.bashrc  /home/${SYSTEM_USER}/
   echo "export PATH=$PATH:\"/home/${SYSTEM_USER}/.local/bin\"" >> /home/${SYSTEM_USER}/.bashrc
+  echo "if [ -f /usr/local/bin/load-singlesshagent.sh ]; then" >> /home/${SYSTEM_USER}/.bashrc
+  echo "   . /usr/local/bin/load-singlesshagent.sh" >> /home/${SYSTEM_USER}/.bashrc
+  echo "fi" >> /home/${SYSTEM_USER}/.bashrc
   PERFORM_CHOWN=true
 fi
 


### PR DESCRIPTION
fixes #24 

This is needed to use passphrase-protected keys that are required
by some HPC centers.
Based on the following howto: https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/ssh.html#using-passphrase-protected-keys-via-an-ssh-agent