### PR TITLE
move postgresql socket file to /tmp

### DIFF
--- a/opt/start-postgres.sh
+++ b/opt/start-postgres.sh
@@ -11,7 +11,7 @@ PSQL_STATUS_CMD="${PGBIN}/pg_ctl -D /home/${SYSTEM_USER}/.postgresql status"
 if [ ! -d /home/${SYSTEM_USER}/.postgresql ]; then
    mkdir /home/${SYSTEM_USER}/.postgresql
    ${PGBIN}/initdb -D /home/${SYSTEM_USER}/.postgresql
-   echo "unix_socket_directories = '/home/${SYSTEM_USER}/.postgresql'" >> /home/${SYSTEM_USER}/.postgresql/postgresql.conf
+   echo "unix_socket_directories = '/tmp'" >> /home/${SYSTEM_USER}/.postgresql/postgresql.conf
    ${PSQL_START_CMD}
 
 # else don't
@@ -27,8 +27,6 @@ else
     # Postgresql was probably not shutdown properly. Cleaning up the mess...
     if ! $running ; then
        echo "" > /home/${SYSTEM_USER}/.postgresql/logfile # empty log files
-       rm -vf /home/${SYSTEM_USER}/.postgresql/.s.PGSQL.5432
-       rm -vf /home/${SYSTEM_USER}/.postgresql/.s.PGSQL.5432.lock
        rm -vf /home/${SYSTEM_USER}/.postgresql/postmaster.pid
        ${PSQL_START_CMD}
    fi


### PR DESCRIPTION
The current setup placed the postgresql socket file in the home
directory of the aiida user.
In the AiiDAlab, this directory is replaced by a bind mount from the
host.

We have recently encountered a setup (host running MacOS 11.5.2, Docker
Desktop 3.6.0 on Apple Silicon) where postgresql was not able to create the socket file
on the mounted directory and failed with [1]

```
LOG:  could not bind Unix address "/home/aiida/.postgresql/.s.PGSQL.5432": Invalid argument
```

Moving the socket file location to /tmp fixes the issue.
Since the socket file is anyhow tied to a specific execution of
postgresql, there should be no downsides to this move.

[1] https://github.com/aiidalab/aiidalab-docker-stack/issues/194#issuecomment-918325330