### PR TITLE
Separate arch builds with different rabbitmq start file

### DIFF
--- a/.github/workflows/build_and_test_on_pr.yml
+++ b/.github/workflows/build_and_test_on_pr.yml
@@ -43,6 +43,7 @@ jobs:
           load: true
           push: false
           tags: aiida-prerequisites:latest
+          build-args: ARCH=amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
       -

--- a/.github/workflows/push_to_dockerhub.yml
+++ b/.github/workflows/push_to_dockerhub.yml
@@ -43,10 +43,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
-        name: Build and push
+        name: Build and push (amd64)
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: ARCH=amd64
+      -
+        name: Build and push (arm64)
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: ARCH=arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/phusion/baseimage-docker/blob/master/Changelog.md
-# Based on Ubuntu 20.04
+# Based on Ubuntu 22.04
 FROM phusion/baseimage:jammy-1.0.0
 LABEL maintainer="AiiDA Team"
 
@@ -8,6 +8,7 @@ LABEL maintainer="AiiDA Team"
 ARG NB_USER="aiida"
 ARG NB_UID="1000"
 ARG NB_GID="1000"
+ARG ARCH
 
 # Use the following variables when running docker:
 # $ docker run -e SYSTEM_USER=aiida2
@@ -66,17 +67,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends  \
 
 # Install conda.
 RUN cd /tmp && \
-    export ARCH=`uname -m` && \
-    if [ "$ARCH" = "x86_64" ]; then \
+   #  export ARCH=`uname -m` && \
+    if [ "$ARCH" = "amd64" ]; then \
        echo "x86_64" && \
        export MINICONDA_ARCH=x86_64 && \
        export MINICONDA_SHA256=3190da6626f86eee8abf1b2fd7a5af492994eb2667357ee4243975cdbb175d7a; \
-    elif [ "$ARCH" = "aarch64" ]; then \
+    elif [ "$ARCH" = "arm64" ]; then \
        echo "aarch64" && \
        export MINICONDA_ARCH=aarch64 && \
        export MINICONDA_SHA256=0c20f121dc4c8010032d64f8e9b27d79e52d28355eb8d7972eafc90652387777; \
     else \
-       echo "unknown arch: ${ARCH}"; \
+       echo "unknown ARCH: ${ARCH}"; \
     fi && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-${MINICONDA_ARCH}.sh && \
     echo "${MINICONDA_SHA256} *Miniconda3-${MINICONDA_VERSION}-Linux-${MINICONDA_ARCH}.sh" | sha256sum -c - && \
@@ -102,7 +103,7 @@ COPY bin/load-singlesshagent.sh /usr/local/bin/load-singlesshagent.sh
 COPY my_init.d/create-system-user.sh /etc/my_init.d/10_create-system-user.sh
 
 # Launch rabbitmq server
-COPY my_init.d/start-rabbitmq.sh /etc/my_init.d/20_start-rabbitmq.sh
+COPY my_init.d/start-rabbitmq-${ARCH}.sh /etc/my_init.d/20_start-rabbitmq.sh
 
 # Launch postgres server.
 COPY opt/start-postgres.sh /opt/start-postgres.sh

--- a/my_init.d/start-rabbitmq-amd64.sh
+++ b/my_init.d/start-rabbitmq-amd64.sh
@@ -11,6 +11,12 @@ chown rabbitmq:rabbitmq "${DIR_RABBITMQ}"
 echo MNESIA_BASE="${DIR_RABBITMQ}" >> /etc/rabbitmq/rabbitmq-env.conf
 echo LOG_BASE="${DIR_RABBITMQ}/log" >> /etc/rabbitmq/rabbitmq-env.conf
 
+# RabbitMQ with versions >= 3.8.15 have reduced some default timeouts 
+# baseimage phusion/baseimage:jammy-1.0.0 running ubuntu 22.04 will install higher version of rabbimq by apt.
+# using workaround from https://github.com/aiidateam/aiida-core/wiki/RabbitMQ-version-to-use 
+# set timeout to 100 hours
+echo "consumer_timeout = 3600000" >> /etc/rabbitmq/rabbitmq.conf
+
 # Explicitly define the node name. This is necessary because the mnesia subdirectory contains the hostname, which by
 # default is set to the value of $(hostname -s), which for docker containers, will be a random hexadecimal string. Upon
 # restart, this will be different and so the original mnesia folder with the persisted data will not be found. The

--- a/my_init.d/start-rabbitmq-arm64.sh
+++ b/my_init.d/start-rabbitmq-arm64.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -em
+
+DIR_RABBITMQ="/home/${SYSTEM_USER}/.rabbitmq"
+
+mkdir -p "${DIR_RABBITMQ}"
+chown rabbitmq:rabbitmq "${DIR_RABBITMQ}"
+
+# Set base directory for RabbitMQ to persist its data. This needs to be set to a folder in the system user's home
+# directory as that is the only folder that is persisted outside of the container.
+echo MNESIA_BASE="${DIR_RABBITMQ}" >> /etc/rabbitmq/rabbitmq-env.conf
+echo LOG_BASE="${DIR_RABBITMQ}/log" >> /etc/rabbitmq/rabbitmq-env.conf
+
+# RabbitMQ with versions >= 3.8.15 have reduced some default timeouts 
+# baseimage phusion/baseimage:jammy-1.0.0 running ubuntu 22.04 will install higher version of rabbimq by apt.
+# using workaround from https://github.com/aiidateam/aiida-core/wiki/RabbitMQ-version-to-use 
+# set timeout to 100 hours
+echo "consumer_timeout = 3600000" >> /etc/rabbitmq/rabbitmq.conf
+
+# Explicitly define the node name. This is necessary because the mnesia subdirectory contains the hostname, which by
+# default is set to the value of $(hostname -s), which for docker containers, will be a random hexadecimal string. Upon
+# restart, this will be different and so the original mnesia folder with the persisted data will not be found. The
+# reason RabbitMQ is built this way is through this way it allows to run multiple nodes on a single machine each with
+# isolated mnesia directories. Since in the AiiDA setup we only need and run a single node, we can simply use localhost.
+echo NODENAME=rabbit@localhost >> /etc/rabbitmq/rabbitmq-env.conf
+
+service rabbitmq-server start


### PR DESCRIPTION
The attempt to separate build for arm64 and amd64 more independent so they can use different ways to set up rabbitmq. Required by https://github.com/aiidateam/aiida-prerequisites/pull/50.